### PR TITLE
[favicon] add fetchStrategy service

### DIFF
--- a/src/favicon/favicon.controller.ts
+++ b/src/favicon/favicon.controller.ts
@@ -25,7 +25,7 @@ export class FaviconController {
     );
 
     if (existingFavicon) {
-      return this.withComputedResponseContentType(res, existingFavicon)
+      return this.returnWithComputedResponseContentType(res, existingFavicon)
     }
 
     await this.faviconService.storeFavicon(params.domainName);
@@ -35,13 +35,13 @@ export class FaviconController {
     );
 
     if (newFavicon) {
-      return this.withComputedResponseContentType(res, newFavicon)
+      return this.returnWithComputedResponseContentType(res, newFavicon)
     }
 
     return res.status(400).send('Could not fetch favicon');
   }
 
-  withComputedResponseContentType(
+  private returnWithComputedResponseContentType(
     res: Response,
     favicon: { extension: string; file: any }
   ) {

--- a/src/favicon/favicon.module.ts
+++ b/src/favicon/favicon.module.ts
@@ -2,9 +2,11 @@ import { Module } from '@nestjs/common';
 import { FaviconController } from './favicon.controller';
 import { FaviconService } from './favicon.service';
 import { FileService } from './file.service';
+import { HtmlFetchStrategy } from './fetch-strategies/html.fetch-strategy';
+import { GoogleFaviconFetchStrategy } from './fetch-strategies/google-favicon.fetch-strategy';
 
 @Module({
   controllers: [FaviconController],
-  providers: [FaviconService, FileService],
+  providers: [FaviconService, FileService, HtmlFetchStrategy, GoogleFaviconFetchStrategy],
 })
 export class FaviconModule {}

--- a/src/favicon/fetch-strategies/google-favicon.fetch-strategy.ts
+++ b/src/favicon/fetch-strategies/google-favicon.fetch-strategy.ts
@@ -1,0 +1,23 @@
+import axios from "axios";
+
+import { FetchStrategy } from "./interfaces/fetch-strategy.interface";
+
+export class GoogleFaviconFetchStrategy implements FetchStrategy {
+  async fetchFaviconUrls(subDomainName: string): Promise<string[]> {
+    const response = await axios.get(
+      `https://t2.gstatic.com/faviconV2?client=SOCIAL&type=FAVICON&fallback_opts=TYPE,SIZE,URL&url=${subDomainName}&size=64`,
+      {
+        headers: {
+          Cookie: '',
+          Connection: 'keep-alive',
+          'user-agent':
+            'Mozilla/5.0 (iPad; CPU OS 16_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.5 Mobile/15E148 Safari/604.1',
+        },
+        responseType: 'arraybuffer',
+      },
+    );
+    return [
+      response.headers['content-location']
+    ];
+  }
+}

--- a/src/favicon/fetch-strategies/html.fetch-strategy.ts
+++ b/src/favicon/fetch-strategies/html.fetch-strategy.ts
@@ -1,0 +1,68 @@
+import axios from "axios";
+import * as cheerio from 'cheerio';
+
+import { FetchStrategy } from "./interfaces/fetch-strategy.interface";
+
+export class HtmlFetchStrategy implements FetchStrategy {
+  async fetchFaviconUrls(subDomainName: string): Promise<string[]> {
+    const response = await axios
+      .get(subDomainName, {
+        timeout: 5000,
+        headers: {
+          Accept: '*/*',
+          'Accept-Encoding': 'gzip, deflate, br',
+          'user-agent':
+            'Mozilla/5.0 (iPad; CPU OS 16_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.5 Mobile/15E148 Safari/604.1',
+        },
+      })
+      .catch(() => null);
+    if (response) {
+      const html = response.data;
+      const redirectedUrl = response.request.res.responseUrl;
+      const baseRedirectedUrl =
+        new URL(redirectedUrl).protocol + '//' + new URL(redirectedUrl).host;
+
+      const faviconUrlsFromHtml = this.getFaviconUrlsFromHtml(
+        html,
+        baseRedirectedUrl,
+      );
+
+      return [
+        ...faviconUrlsFromHtml,
+        `${baseRedirectedUrl}/favicon.ico`,
+      ];
+    }
+    return []
+  }
+
+  private getFaviconUrlsFromHtml(html: string, baseUrl: string): string[] {
+    const $ = cheerio.load(html);
+    const faviconUrls = [];
+    $('link[rel=icon], link[rel="shortcut icon"]').each((i, icon) => {
+      const href = $(icon).attr('href');
+      faviconUrls.push(this.makeAbsoluteUrl(href, baseUrl));
+    });
+
+    $('meta[itemprop="image"]').each((i, icon) => {
+      const href = $(icon).attr('content');
+      faviconUrls.push(this.makeAbsoluteUrl(href, baseUrl));
+    });
+
+    return faviconUrls;
+  }
+
+  private makeAbsoluteUrl(url: string, baseUrl: string): string {
+    const trimmedBaseUrl = baseUrl.replace(/\/$/, '');
+    const absolutePattern = /^https?:\/\//i;
+    if (absolutePattern.test(url)) {
+      return url;
+    } else if (url.startsWith('//')) {
+      return `https:${url}`;
+    } else if (url.startsWith('/')) {
+      return `${trimmedBaseUrl}${url}`;
+    } else {
+      return `${trimmedBaseUrl}/${url}`;
+    }
+  }
+
+}

--- a/src/favicon/fetch-strategies/interfaces/fetch-strategy.interface.ts
+++ b/src/favicon/fetch-strategies/interfaces/fetch-strategy.interface.ts
@@ -1,0 +1,3 @@
+export interface FetchStrategy {
+  fetchFaviconUrls(subDomainName: string): Promise<Array<string>>;
+}


### PR DESCRIPTION
## Context
We are adding a new fetchStrategy class for each strategy. As of today we can fetch with GoogleFavicon or parse the Html.

## Test
Locally
<img width="226" alt="Screenshot 2023-08-02 at 12 45 42" src="https://github.com/twentyhq/favicon/assets/1834158/9afd7f45-d5c2-4294-b49f-8692833328f6">
