### PR TITLE
Add /health, /healthz and redirect root to README

### DIFF
--- a/src/favicon/favicon.controller.ts
+++ b/src/favicon/favicon.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Param, Res } from '@nestjs/common';
+import { Controller, Get, Param, Redirect, Res } from '@nestjs/common';
 import { FaviconService } from './favicon.service';
 import { Response } from 'express';
 import { DEFAULT_SIZE, SUPPORTED_SIZES } from './favicon.constants';
@@ -7,6 +7,21 @@ import { Readable } from 'stream';
 @Controller()
 export class FaviconController {
   constructor(private readonly faviconService: FaviconService) {}
+
+  @Get()
+  @Redirect('https://github.com/twentyhq/favicon/blob/main/README.md', 301)
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  redirectToReadme() {}
+
+  @Get('/health')
+  checkHealth(@Res() res: Response) {
+    res.status(200).send();
+  }
+
+  @Get('/healthz')
+  checkHealthz(@Res() res: Response) {
+    res.status(200).send();
+  }
 
   @Get('/favicon.ico')
   async getOwnFavicon() {


### PR DESCRIPTION
## Context
Instead of showing an error, [https://favicon.twenty.com/](https://favicon.twenty.com/) should now redirect to the project README
We are also adding 2 health check endpoints, /healthz being used by kubernetes 
