### PR TITLE
Add 16px support

### DIFF
--- a/src/favicon/favicon.constants.ts
+++ b/src/favicon/favicon.constants.ts
@@ -1,3 +1,3 @@
 export const DEFAULT_SIZE = '192';
 
-export const SUPPORTED_SIZES = [32, 64, 128, 180, 192];
+export const SUPPORTED_SIZES = [16, 32, 64, 128, 180, 192];


### PR DESCRIPTION
We are still seeing some failures for websites that only serve 16px favicons so we are adding support for that size.