### PR TITLE
Add Placeholder Favicon When Favicon Not Found

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ You can also specify a size with an optional parameter [https://twenty-icons.com
 We support and store `[16x16, 32x32, 64x64, 128x128, 180x180, 192x192]` sizes.
 If no size is specified, the highest available supported size will be used.
 
+If a domain does not have a favicon, you can **force a placeholder favicon** by adding `?withFallbackPlaceholder=true` to the URL.
+For example, if you're looking to display a placeholder favicon for `example.com`, you can use
+<img src="https://twenty-icons.com/example.com/64?withFallbackPlaceholder=true" alt="Favicon" />
+
 ## Example
 
 There are many other use-cases, mostly for B2B companies.
@@ -166,7 +170,7 @@ For scalable and robust storage, the application also integrates with Amazon S3.
 To configure Amazon S3 as your storage preference:
 
 1. Modify the `STORAGE_TYPE` variable in the `.env` file to reflect `s3`.
-   
+
 2. Populate the Amazon S3-specific environment variables in the `.env` file:
 
    ```env

--- a/src/favicon/favicon.controller.ts
+++ b/src/favicon/favicon.controller.ts
@@ -62,6 +62,10 @@ export class FaviconController {
       return this.returnWithComputedResponseContentType(res, newFavicon);
     }
 
+    if (res.req.query.withFallbackPlaceholder) {
+      return res.redirect('https://i.imghippo.com/files/bri9020Qc.png');
+    }
+
     return res.status(404).send('Could not fetch favicon');
   }
 


### PR DESCRIPTION
Added a placeholder favicon when no favicon is found, using the URL parameter ?withFallbackPlaceholder=true. The placeholder has the default size (192x192) unless a specific size is requested.

Additionally, updated the README to include instructions on how to use this feature.