### PR TITLE
Fix broken Twenty image in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,16 @@ There are many other use-cases, mostly for B2B companies.
 For example if you are a SaaS you could look at the domain when someone signups and automatically set their workspace logo based on that.
 
 In our case, we built it because we needed it for our CRM [Twenty](https://github.com/twentyhq/twenty):
-[![Twenty](https://raw.githubusercontent.com/twentyhq/twenty/main/docs/static/img/preview-light.png)](https://github.com/twentyhq/twenty)
+
+<p align="center">
+  <a href="https://github.com/twentyhq/twenty">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/twentyhq/twenty/v0.12.0/packages/twenty-docs/static/img/preview-dark.png">
+      <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/twentyhq/twenty/v0.12.0/packages/twenty-docs/static/img/preview-light.png">
+      <img src="https://raw.githubusercontent.com/twentyhq/twenty/v0.12.0/packages/twenty-docs/static/img/preview-light.png" alt="Companies view" />
+    </picture>
+  </a>
+</p>
 
 ## Features
 


### PR DESCRIPTION
**Before:**
![image](https://github.com/user-attachments/assets/867a5cbb-6195-4950-9c39-78d6ee4e0d04)

---

**After:**
![image](https://github.com/user-attachments/assets/ce5ad887-3a65-45ce-9d3a-21717f3545f8)

---

I applied what [is currently in use](https://github.com/twentyhq/favicon/blob/e01441c35a0038d7860c24855275418d9ac51160/README.md?plain=1#L7-L15) in the main repo.

Pretty insignificant change but I am a perfectionist, broken images trigger me :upside_down_face: 