### PR TITLE
Add placeholder favicon support

### DIFF
--- a/src/favicon/utils/image-manipulation.ts
+++ b/src/favicon/utils/image-manipulation.ts
@@ -89,4 +89,34 @@ export class ImageManipulation {
       favicon.width / favicon.height < 1.1
     );
   }
+
+  static isValidHexColor(color: string): boolean {
+    const hexColorPattern = /^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$/;
+    return hexColorPattern.test(color);
+  }
+
+  static async generatePlaceholder(
+    domainName: string,
+    size: number,
+    backgroundColor: string,
+    textColor: string,
+  ): Promise<Buffer> {
+    const firstLetter = domainName.charAt(0).toUpperCase();
+    const fontSize = Math.floor(size * 0.75);
+
+    const svg = `
+      <svg width="${size}" height="${size}" xmlns="http://www.w3.org/2000/svg">
+        <rect width="${size}" height="${size}" fill="${backgroundColor}"/>
+        <text x="50%" y="50%" dy="0.35em" font-family="Arial, sans-serif" font-size="${fontSize}"
+              font-weight="900" fill="${textColor}" text-anchor="middle">
+          ${firstLetter}
+        </text>
+      </svg>
+    `;
+
+    return await sharp(Buffer.from(svg))
+      .resize(size, size)
+      .png()
+      .toBuffer();
+  }
 }


### PR DESCRIPTION
Closes https://github.com/twentyhq/favicon/issues/31.

It takes the first letter of the domain and generates a placeholder image. It also respects the size if specified.

Examples:

```
http://127.0.0.1:3000/ttttest.com?placeholder=true
```

```
http://127.0.0.1:3000/ttttest.com?placeholder=000000
```

```
http://127.0.0.1:3000/ttttest.com?placeholder=ffffff&placeholderText=000000
```

<img width="332" height="331" alt="image" src="https://github.com/user-attachments/assets/ef1016ff-6a62-4413-a9c2-b1247e63eb15" />

<br />

<img width="332" height="331" alt="image" src="https://github.com/user-attachments/assets/ed6f4088-687d-4fba-9edc-ce8740675963" />

<br />

<img width="332" height="331" alt="image" src="https://github.com/user-attachments/assets/172e0bb5-4dd5-401e-8947-89e716833070" />

