### PR TITLE
chore: basic ci setup to automate building and testing

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,5 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 3
-    versioning-strategy: "lockfile-only"
     assignees:
       - "mabdullahabaid"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    name: Test & Build
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Setup Yarn
+        run: corepack prepare yarn@4.11.0 --activate
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Run linter
+        run: yarn lint
+
+      - name: Run unit tests
+        run: yarn test
+
+      - name: Build project
+        run: yarn build
+
+      - name: Run e2e tests
+        run: yarn test:e2e


### PR DESCRIPTION
Removed version-strategy from dependabot.yml to also update package.json with yarn.lock.

Added a basic workflow to build the app and run test cases on every PR - a step towards making dependabot updates simpler to manage.