### PR TITLE
fix: bump undici 7.24.7 -> 7.28.0 (Dependabot transitive vulns)

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -9840,9 +9840,9 @@ __metadata:
   linkType: hard
 
 "undici@npm:^7.19.0":
-  version: 7.24.7
-  resolution: "undici@npm:7.24.7"
-  checksum: 10c0/779c67e81677324763ea00ea547ba74757472ebe2625d046d592434ee19d9d148fe0eaef7006c0185096614249ac0f179e7f559b202b518af8d587e9548559b6
+  version: 7.28.0
+  resolution: "undici@npm:7.28.0"
+  checksum: 10c0/fe781983a26098795e99bb1f64906cbb7d0bcaa029a26baade007b53ea67f2631d189b8f9671a31f4c8d0cb3773b7559608628ba54452fef51fec90e7c78bb0d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Bumps **undici 7.24.7 → 7.28.0** to clear **7 Dependabot alerts**. undici is transitive via **cheerio** (`cheerio@1.2.0` → `undici@^7.19.0`); the caret range already permits 7.28.0, so a recursive `yarn up -R undici` lifts it with **no resolution and no `package.json` change** — same lockfile-only approach as #122.

## Alerts cleared

| Severity | Advisory | Alert |
|---|---|---|
| high | GHSA-vmh5-mc38-953g | [147](https://github.com/twentyhq/favicon/security/dependabot/147) |
| high | GHSA-hm92-r4w5-c3mj | [150](https://github.com/twentyhq/favicon/security/dependabot/150) |
| high | GHSA-vxpw-j846-p89q | [153](https://github.com/twentyhq/favicon/security/dependabot/153) |
| medium | GHSA-pr7r-676h-xcf6 | [148](https://github.com/twentyhq/favicon/security/dependabot/148) |
| medium | GHSA-p88m-4jfj-68fv | [152](https://github.com/twentyhq/favicon/security/dependabot/152) |
| low | GHSA-35p6-xmwp-9g52 | [151](https://github.com/twentyhq/favicon/security/dependabot/151) |
| low | GHSA-g8m3-5g58-fq7m | [154](https://github.com/twentyhq/favicon/security/dependabot/154) |

## Verification

- `yarn install --immutable` passes (CI parity).
- Diff is `yarn.lock`-only (3 insertions, 3 deletions); undici resolves to 7.28.0, no 7.24.7 remains.
- 7.28.0 is the latest 7.x — cheerio's `^7.19.0` caps below 8.0.0, so no major jump.
