### PR TITLE
fix: bump form-data 4.0.5 -> 4.0.6 (Dependabot transitive vuln)

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -6379,15 +6379,15 @@ __metadata:
   linkType: hard
 
 "form-data@npm:^4.0.0, form-data@npm:^4.0.5":
-  version: 4.0.5
-  resolution: "form-data@npm:4.0.5"
+  version: 4.0.6
+  resolution: "form-data@npm:4.0.6"
   dependencies:
     asynckit: "npm:^0.4.0"
     combined-stream: "npm:^1.0.8"
     es-set-tostringtag: "npm:^2.1.0"
-    hasown: "npm:^2.0.2"
-    mime-types: "npm:^2.1.12"
-  checksum: 10c0/dd6b767ee0bbd6d84039db12a0fa5a2028160ffbfaba1800695713b46ae974a5f6e08b3356c3195137f8530dcd9dfcb5d5ae1eeff53d0db1e5aad863b619ce3b
+    hasown: "npm:^2.0.4"
+    mime-types: "npm:^2.1.35"
+  checksum: 10c0/43947a77bf0ff45c6ceed789778982d47a3f3e720a74b71721174ebf3310a5f1a8be1d6b38a3ee3688e8a18a2c4273073ec0844cd37efda3eaf46d41c9c318ff
   languageName: node
   linkType: hard
 
@@ -6694,6 +6694,15 @@ __metadata:
   dependencies:
     function-bind: "npm:^1.1.2"
   checksum: 10c0/3769d434703b8ac66b209a4cca0737519925bbdb61dd887f93a16372b14694c63ff4e797686d87c90f08168e81082248b9b028bad60d4da9e0d1148766f56eb9
+  languageName: node
+  linkType: hard
+
+"hasown@npm:^2.0.4":
+  version: 2.0.4
+  resolution: "hasown@npm:2.0.4"
+  dependencies:
+    function-bind: "npm:^1.1.2"
+  checksum: 10c0/2d8de939e270b70618f8cebb69746620db10617dbb495bc66ddad326955ea24d3ca4af133aff3eb7c1853e0218f867bc2b050ec26fe02e3aea58f880ffc5e506
   languageName: node
   linkType: hard
 
@@ -7995,7 +8004,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mime-types@npm:^2.1.12, mime-types@npm:^2.1.27, mime-types@npm:~2.1.24":
+"mime-types@npm:^2.1.27, mime-types@npm:^2.1.35, mime-types@npm:~2.1.24":
   version: 2.1.35
   resolution: "mime-types@npm:2.1.35"
   dependencies:


### PR DESCRIPTION
## Summary

Bumps **form-data 4.0.5 → 4.0.6** to clear **1 high Dependabot alert** (GHSA-hmw2-7cc7-3qxx). form-data is transitive via **axios** (`axios@1.17.0`) and **superagent** (`superagent@10.3.0`), both declaring `form-data@^4.0.5`; the caret already permits 4.0.6, so a recursive `yarn up -R form-data` lifts it with **no resolution and no `package.json` change** — same lockfile-only approach as #122.

## Alert cleared

| Severity | Advisory | Alert |
|---|---|---|
| high | GHSA-hmw2-7cc7-3qxx | [149](https://github.com/twentyhq/favicon/security/dependabot/149) |

## Verification

- `yarn install --immutable` passes (CI parity).
- Diff is `yarn.lock`-only; form-data resolves to 4.0.6, no 4.0.5 remains.
- 4.0.6 is the latest 4.x (consumers cap below 5.0.0), so no major jump.
