### PR TITLE
fix: bump tar 7.5.13 -> 7.5.16 (Dependabot transitive vuln)

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -9482,15 +9482,15 @@ __metadata:
   linkType: hard
 
 "tar@npm:^7.5.2":
-  version: 7.5.13
-  resolution: "tar@npm:7.5.13"
+  version: 7.5.16
+  resolution: "tar@npm:7.5.16"
   dependencies:
     "@isaacs/fs-minipass": "npm:^4.0.0"
     chownr: "npm:^3.0.0"
     minipass: "npm:^7.1.2"
     minizlib: "npm:^3.1.0"
     yallist: "npm:^5.0.0"
-  checksum: 10c0/5c65b8084799bde7a791593a1c1a45d3d6ee98182e3700b24c247b7b8f8654df4191642abbdb07ff25043d45dcff35620827c3997b88ae6c12040f64bed5076b
+  checksum: 10c0/4f37f3c4bd2ca2755fd736a5df1d573c1a868ec1b1e893346aeafa95ac510f9e2fd1469420bd866cc7904799e5bd4ac62b5d4f03fe27747d6e1e373b44505c5c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Bumps **tar 7.5.13 → 7.5.16** to clear **1 medium Dependabot alert** (GHSA-vmf3-w455-68vh). tar is transitive via **node-gyp** (`node-gyp@12.1.0` → `tar@^7.5.2`); the caret already permits 7.5.16, so a recursive `yarn up -R tar` lifts it with **no resolution and no `package.json` change** — same lockfile-only approach as #122.

## Alert cleared

| Severity | Advisory | Alert |
|---|---|---|
| medium | GHSA-vmf3-w455-68vh | [155](https://github.com/twentyhq/favicon/security/dependabot/155) |

## Verification

- `yarn install --immutable` passes (CI parity).
- Diff is `yarn.lock`-only; tar resolves to 7.5.16, no 7.5.13 remains.
- 7.5.16 is the latest 7.x (node-gyp's `^7.5.2` caps below 8.0.0), so no major jump.
