### PR TITLE
fix: pin multer 2.2.0 via resolution (Dependabot transitive vulns)

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,10 @@
     "tsconfig-paths": "^4.2.0",
     "typescript": "^5.9.3"
   },
+  "resolutions": {
+    "@nestjs/platform-express/multer": "2.2.0"
+  },
+  "//resolutions": "Each entry forces a version OUTSIDE some parent's declared range where no fixed upstream release exists; drop each once its blocker ships. @nestjs/platform-express/multer 2.2.0 -> GHSA-72gw-mp4g-v24j / CVE-2026-5079 (high, DoS via deeply nested field names) & GHSA-3p4h-7m6x-2hcm / CVE-2026-5038 (medium, DoS via incomplete cleanup of aborted uploads), both vulnerable <2.2.0; @nestjs/platform-express hard-pins multer 2.1.1 exact (no caret, still 2.1.1 in latest 11.1.27, 12.0 alpha-only) so no parent upgrade carries the fix; scoped to @nestjs/platform-express as multer's sole consumer; drop once @nestjs/platform-express depends on multer >=2.2.0.",
   "jest": {
     "moduleFileExtensions": [
       "js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8160,15 +8160,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"multer@npm:2.1.1":
-  version: 2.1.1
-  resolution: "multer@npm:2.1.1"
+"multer@npm:2.2.0":
+  version: 2.2.0
+  resolution: "multer@npm:2.2.0"
   dependencies:
     append-field: "npm:^1.0.0"
     busboy: "npm:^1.6.0"
     concat-stream: "npm:^2.0.0"
     type-is: "npm:^1.6.18"
-  checksum: 10c0/2ec4e02833b20f403cfb879d4b64d2a9070d902b9deae7aef18a6faadb707d7665385456cf540aa8a6dadfe3d4c5fc8e0e7b0675b94e1077048b1125426deee6
+  checksum: 10c0/7aa366d89042427347b6ab8e4a203405d7fe942e4a3095648a14526fcf3691d98ffc2da62abf85d8aca0a341f828168eb197b33cfdcfcce29d6ef593a5625591
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Pins **multer 2.1.1 → 2.2.0** to clear **2 Dependabot alerts** (1 high, 1 medium). Unlike the undici/form-data/tar PRs, multer **cannot** be lifted by `yarn up`: its only consumer, `@nestjs/platform-express`, **hard-pins multer to exactly `2.1.1`** (no caret), and the latest release (11.1.27) *still* pins 2.1.1 — 12.0 is alpha-only. So no parent upgrade carries the fix.

The minimal fix is a **scoped resolution** targeting just that parent chain:

```json
"resolutions": {
  "@nestjs/platform-express/multer": "2.2.0"
}
```

This forces multer **2.2.0** only where `@nestjs/platform-express` pulls it (its sole consumer per `yarn why`), leaving the rest of the tree untouched. 2.2.0 is the security release on the 2.x line and is API-compatible with 2.1.1.

> This is the **first `resolutions` entry** in this repo. It's documented in a sibling **`//resolutions`** doc key — advisories, the exact-pin rationale, scope, and the drop condition — mirroring the convention in `twentyhq/twenty`, which carries the **identical** `@nestjs/platform-express/multer 2.2.0` resolution.

## Alerts cleared

| Severity | Advisory | CVE | Alert |
|---|---|---|---|
| high | GHSA-72gw-mp4g-v24j | CVE-2026-5079 | [146](https://github.com/twentyhq/favicon/security/dependabot/146) |
| medium | GHSA-3p4h-7m6x-2hcm | CVE-2026-5038 | [145](https://github.com/twentyhq/favicon/security/dependabot/145) |

## Verification

- `yarn install --immutable` passes after the resolution (CI parity); the `//resolutions` doc key is inert (lockfile unchanged).
- multer now resolves to **2.2.0**; no 2.1.1 remains in the tree.
- Diff is `package.json` (resolutions block + `//resolutions` doc key) + `yarn.lock` only.
