### PR TITLE
chore: disable dependabot version-update PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,6 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 3
+    open-pull-requests-limit: 0
     assignees:
       - "mabdullahabaid"


### PR DESCRIPTION
## Summary

Disables Dependabot **routine version-update PRs** by setting `open-pull-requests-limit: 0`, mirroring the change Charles made in `twentyhq/twenty` ([#22119](https://github.com/twentyhq/twenty/pull/22119)).

`open-pull-requests-limit` governs only **version updates** (the routine `bump X from 1.2 to 1.3` PRs). **Security updates** are a *separate* Dependabot channel **not** affected by this limit — so security fixes keep flowing (as with #123–#126); only the routine bump churn is silenced.

## Change

```diff
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 3
+    open-pull-requests-limit: 0
     assignees:
       - "mabdullahabaid"
```
