### PR TITLE
fix: bump js-yaml 4.1.1 -> 4.2.0 (Dependabot transitive vuln)

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -7648,13 +7648,13 @@ __metadata:
   linkType: hard
 
 "js-yaml@npm:^4.1.0, js-yaml@npm:^4.1.1":
-  version: 4.1.1
-  resolution: "js-yaml@npm:4.1.1"
+  version: 4.2.0
+  resolution: "js-yaml@npm:4.2.0"
   dependencies:
     argparse: "npm:^2.0.1"
   bin:
     js-yaml: bin/js-yaml.js
-  checksum: 10c0/561c7d7088c40a9bb53cc75becbfb1df6ae49b34b5e6e5a81744b14ae8667ec564ad2527709d1a6e7d5e5fa6d483aa0f373a50ad98d42fde368ec4a190d4fae7
+  checksum: 10c0/1916456c118746603b067d74bbcbb0445d9a1d5e474ad4ae775e7b20525bed902e01d9d97dd0c81fcd8d4f596162309d0eb057f4aa38f3e9647f14075e9dea45
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Bumps **js-yaml 4.1.1 → 4.2.0** to clear **1 medium Dependabot alert** (GHSA-h67p-54hq-rp68 / CVE-2026-53550 — quadratic-complexity DoS in YAML merge-key handling via repeated aliases, vulnerable `<=4.1.1`). js-yaml 4.1.1 is transitive via **@eslint/eslintrc** (`^4.1.1`) and **cosmiconfig** (`^4.1.0`); both carets already permit 4.2.0, so a recursive `yarn up -R js-yaml` lifts it with **no resolution and no `package.json` change**. (Same advisory + fix as twenty's js-yaml bump.)

## The js-yaml 3.x copy (left as-is)

`@istanbuljs/load-nyc-config` (jest coverage) declares `js-yaml ^3.13.1` → **3.14.2**, a different major with **no 4.2.0 fix** (3.x is EOL). It only parses first-party `.nycrc` YAML, so the merge-key DoS isn't reachable. If Dependabot keeps an alert on that 3.x copy after merge, it's a dismiss candidate (no upstream fix).

## Alert cleared

| Severity | Advisory | CVE | Alert |
|---|---|---|---|
| medium | GHSA-h67p-54hq-rp68 | CVE-2026-53550 | [157](https://github.com/twentyhq/favicon/security/dependabot/157) |

## Verification

- `yarn install --immutable` passes (CI parity).
- Diff is `yarn.lock`-only; the js-yaml 4.x copy resolves to 4.2.0, no 4.1.1 remains.
