### PR TITLE
fix: evict js-yaml 3.x via resolution (Dependabot transitive vuln)

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,9 +67,10 @@
     "typescript": "^5.9.3"
   },
   "resolutions": {
-    "@nestjs/platform-express/multer": "2.2.0"
+    "@nestjs/platform-express/multer": "2.2.0",
+    "@istanbuljs/load-nyc-config/js-yaml": "4.2.0"
   },
-  "//resolutions": "Each entry forces a version OUTSIDE some parent's declared range where no fixed upstream release exists; drop each once its blocker ships. @nestjs/platform-express/multer 2.2.0 -> GHSA-72gw-mp4g-v24j / CVE-2026-5079 (high, DoS via deeply nested field names) & GHSA-3p4h-7m6x-2hcm / CVE-2026-5038 (medium, DoS via incomplete cleanup of aborted uploads), both vulnerable <2.2.0; @nestjs/platform-express hard-pins multer 2.1.1 exact (no caret, still 2.1.1 in latest 11.1.27, 12.0 alpha-only) so no parent upgrade carries the fix; scoped to @nestjs/platform-express as multer's sole consumer; drop once @nestjs/platform-express depends on multer >=2.2.0.",
+  "//resolutions": "Each entry forces a version OUTSIDE some parent's declared range where no fixed upstream release exists; drop each once its blocker ships. @nestjs/platform-express/multer 2.2.0 -> GHSA-72gw-mp4g-v24j / CVE-2026-5079 (high, DoS via deeply nested field names) & GHSA-3p4h-7m6x-2hcm / CVE-2026-5038 (medium, DoS via incomplete cleanup of aborted uploads), both vulnerable <2.2.0; @nestjs/platform-express hard-pins multer 2.1.1 exact (no caret, still 2.1.1 in latest 11.1.27, 12.0 alpha-only) so no parent upgrade carries the fix; scoped to @nestjs/platform-express as multer's sole consumer; drop once @nestjs/platform-express depends on multer >=2.2.0. @istanbuljs/load-nyc-config/js-yaml 4.2.0 -> GHSA-h67p-54hq-rp68 / CVE-2026-53550 (medium, js-yaml quadratic-complexity DoS in YAML merge-key handling, vulnerable <=4.1.1); @istanbuljs/load-nyc-config (EOL, latest 1.1.0) declares js-yaml ^3.13.1 -> 3.14.2 so no parent upgrade carries the fix; it is the sole remaining js-yaml 3.x consumer and calls only yaml.load (present and API-compatible in 4.x, unlike the removed safeLoad) so forcing 4.2.0 is safe; scoped to @istanbuljs/load-nyc-config; drop once it depends on js-yaml >=4.2.0 or leaves the babel-plugin-istanbul chain.",
   "jest": {
     "moduleFileExtensions": [
       "js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4473,15 +4473,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"argparse@npm:^1.0.7":
-  version: 1.0.10
-  resolution: "argparse@npm:1.0.10"
-  dependencies:
-    sprintf-js: "npm:~1.0.2"
-  checksum: 10c0/b2972c5c23c63df66bca144dbc65d180efa74f25f8fd9b7d9a0a6c88ae839db32df3d54770dcb6460cf840d232b60695d1a6b1053f599d84e73f7437087712de
-  languageName: node
-  linkType: hard
-
 "argparse@npm:^2.0.1":
   version: 2.0.1
   resolution: "argparse@npm:2.0.1"
@@ -5884,7 +5875,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esprima@npm:^4.0.0, esprima@npm:^4.0.1":
+"esprima@npm:^4.0.1":
   version: 4.0.1
   resolution: "esprima@npm:4.0.1"
   bin:
@@ -7568,19 +7559,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-yaml@npm:^3.13.1":
-  version: 3.14.2
-  resolution: "js-yaml@npm:3.14.2"
-  dependencies:
-    argparse: "npm:^1.0.7"
-    esprima: "npm:^4.0.0"
-  bin:
-    js-yaml: bin/js-yaml.js
-  checksum: 10c0/3261f25912f5dd76605e5993d0a126c2b6c346311885d3c483706cd722efe34f697ea0331f654ce27c00a42b426e524518ec89d65ed02ea47df8ad26dcc8ce69
-  languageName: node
-  linkType: hard
-
-"js-yaml@npm:^4.1.0, js-yaml@npm:^4.1.1":
+"js-yaml@npm:4.2.0, js-yaml@npm:^4.1.0, js-yaml@npm:^4.1.1":
   version: 4.2.0
   resolution: "js-yaml@npm:4.2.0"
   dependencies:
@@ -9184,13 +9163,6 @@ __metadata:
   version: 0.6.1
   resolution: "source-map@npm:0.6.1"
   checksum: 10c0/ab55398007c5e5532957cb0beee2368529618ac0ab372d789806f5718123cc4367d57de3904b4e6a4170eb5a0b0f41373066d02ca0735a0c4d75c7d328d3e011
-  languageName: node
-  linkType: hard
-
-"sprintf-js@npm:~1.0.2":
-  version: 1.0.3
-  resolution: "sprintf-js@npm:1.0.3"
-  checksum: 10c0/ecadcfe4c771890140da5023d43e190b7566d9cf8b2d238600f31bec0fc653f328da4450eb04bd59a431771a8e9cc0e118f0aa3974b683a4981b4e07abc2a5bb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Closes the remaining **js-yaml** Dependabot alert ([#157](https://github.com/twentyhq/favicon/security/dependabot/157) — GHSA-h67p-54hq-rp68 / CVE-2026-53550, medium, merge-key DoS).

[#128](https://github.com/twentyhq/favicon/pull/128) lifted the js-yaml **4.x** copy to 4.2.0, but a **3.14.2** copy survived via `babel-plugin-istanbul@7.0.1 → @istanbuljs/load-nyc-config@1.1.0` (jest coverage). load-nyc-config is **EOL** (latest 1.1.0) and declares `js-yaml ^3.13.1`, so no parent upgrade reaches 4.2.0.

## Why a resolution is safe here

load-nyc-config's source calls `require('js-yaml').load(...)` — **not** the `safeLoad` API that js-yaml 4.x removed. `load()` exists and is API-compatible in 4.x (same signature; 4.x just defaults to the safe schema, irrelevant for trusted `.nycrc` config). It's also the **sole** remaining js-yaml 3.x consumer in the tree, so forcing it evicts the 3.x copy entirely.

```json
"resolutions": {
  "@nestjs/platform-express/multer": "2.2.0",
  "@istanbuljs/load-nyc-config/js-yaml": "4.2.0"
}
```

Documented in the `//resolutions` doc key (advisory, EOL-parent rationale, the `yaml.load` API-compat note, scope, drop condition).

## Alert cleared

| Severity | Advisory | CVE | Alert |
|---|---|---|---|
| medium | GHSA-h67p-54hq-rp68 | CVE-2026-53550 | [157](https://github.com/twentyhq/favicon/security/dependabot/157) |

## Verification

- `yarn install --immutable` passes (CI parity).
- js-yaml `3.14.2` is **gone** — only `4.2.0` remains in the tree.
- Diff is `package.json` (resolution + doc) + `yarn.lock` only.
