### PR TITLE
fix: bump tar 7.5.16 -> 7.5.22 (Dependabot)

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -9396,15 +9396,15 @@ __metadata:
   linkType: hard
 
 "tar@npm:^7.5.2":
-  version: 7.5.16
-  resolution: "tar@npm:7.5.16"
+  version: 7.5.22
+  resolution: "tar@npm:7.5.22"
   dependencies:
     "@isaacs/fs-minipass": "npm:^4.0.0"
     chownr: "npm:^3.0.0"
     minipass: "npm:^7.1.2"
     minizlib: "npm:^3.1.0"
     yallist: "npm:^5.0.0"
-  checksum: 10c0/4f37f3c4bd2ca2755fd736a5df1d573c1a868ec1b1e893346aeafa95ac510f9e2fd1469420bd866cc7904799e5bd4ac62b5d4f03fe27747d6e1e373b44505c5c
+  checksum: 10c0/1311f6be85a8157ac4c9147bae43e13923d2a1aae15e4aa1bd5239e4e03d2cf53cfe103dde7f35832fbb4c938b042856bc8e9a0afd29abd05e2d1608788c4fea
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Bumps **tar 7.5.16 -> 7.5.22**, clearing **4 Dependabot alerts** including the critical one:

| Severity | Advisory | Vulnerable | Alert |
|---|---|---|---|
| critical | GHSA-23hp-3jrh-7fpw | `<= 7.5.18` | [171](https://github.com/twentyhq/favicon/security/dependabot/171) |
| high | GHSA-8x88-c5mf-7j5w | `<= 7.5.17` | [170](https://github.com/twentyhq/favicon/security/dependabot/170) |
| medium | GHSA-w8wr-v893-vjvp | `<= 7.5.17` | [173](https://github.com/twentyhq/favicon/security/dependabot/173) |
| medium | GHSA-gvwx-54wh-qm9j | `<= 7.5.16` | [172](https://github.com/twentyhq/favicon/security/dependabot/172) |

tar is transitive behind a single caret range (`^7.5.2`), so a recursive `yarn up -R tar` lifts it with **no resolution and no `package.json` change**.

Landing on 7.5.22 (latest) also covers **GHSA-r292-9mhp-454m** (`<= 7.5.20`), the newer node-tar advisory that has already been flagged upstream in `twentyhq/twenty`, so this stays ahead of the current chain rather than only meeting the 7.5.19 floor.

## Verification

- `yarn install --immutable` passes.
- Diff is `yarn.lock` only; tar resolves to 7.5.22, no 7.5.16 remains.
