### PR TITLE
fix: bump axios 1.17.0 -> 1.18.1 (Dependabot)

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -4509,14 +4509,14 @@ __metadata:
   linkType: hard
 
 "axios@npm:^1.15.0":
-  version: 1.17.0
-  resolution: "axios@npm:1.17.0"
+  version: 1.18.1
+  resolution: "axios@npm:1.18.1"
   dependencies:
     follow-redirects: "npm:^1.16.0"
     form-data: "npm:^4.0.5"
     https-proxy-agent: "npm:^5.0.1"
     proxy-from-env: "npm:^2.1.0"
-  checksum: 10c0/c4fa19ff3a3a63bde48beec03ad816b133b9a6385cccffffe172577ab18c6a70e299280d57f12c80c867fe25df41f92cb91d3a8258708a6d2be3e9e085f92650
+  checksum: 10c0/9d9378a3af0d0ad730a52ad9d15ec7201f3926ad6e7e8bbffc5ae21ca2835ad11d1d9598698f5dd9718917486039f55ea1d7dc23d8e44fa827a55cc3262c02fc
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Bumps **axios 1.17.0 -> 1.18.1**, clearing **10 Dependabot alerts** (1 high, 9 medium) - every one fixed in 1.18.0:

| Severity | Advisories |
|---|---|
| high | GHSA-gcfj-64vw-6mp9 |
| medium | GHSA-mmx7-hfxf-jppx, GHSA-7q8q-rj6j-mhjq, GHSA-42h9-826w-cgv3, GHSA-pmv8-rq9r-6j72, GHSA-jqh4-m9w3-8hp9, GHSA-mwf2-3pr3-8698, GHSA-hcpx-6fm6-wx23, GHSA-f4gw-2p7v-4548, GHSA-xj6q-8x83-jv6g |

axios is a **direct dependency** declared `^1.15.0`; the caret already permits 1.18.x, so a recursive `yarn up -R axios` lifts it with **no resolution and no `package.json` change** (the declared range stays as-is, matching Dependabot's lockfile-only strategy).

## Verification

- `yarn install --immutable` passes.
- Diff is `yarn.lock` only; axios resolves to 1.18.1, no 1.17.0 remains.
