### PR TITLE
fix: bump fast-uri 3.1.2 -> 3.1.4 (Dependabot)

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -6069,9 +6069,9 @@ __metadata:
   linkType: hard
 
 "fast-uri@npm:^3.0.1":
-  version: 3.1.2
-  resolution: "fast-uri@npm:3.1.2"
-  checksum: 10c0/5b35641895959f3f7ab7a7b1b5542bded159346f25ec9f256817b206d50b64eda5828e90d605a2e2fc645c90519a7259c2bab2c942ee728c88b88e5be21b090d
+  version: 3.1.4
+  resolution: "fast-uri@npm:3.1.4"
+  checksum: 10c0/f90948821ceb49980f64f89b8216ba498f5957f26035be813526a55b6145d26cbd63ef5618d5205a3292b31edc9c08589749350cd72bd86c7095eb434dceb757
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Bumps **fast-uri 3.1.2 -> 3.1.4**, clearing **2 high Dependabot alerts**:

| Advisory | Vulnerable | Fixed | Alert |
|---|---|---|---|
| GHSA-4c8g-83qw-93j6 | `>= 3.0.0, < 3.1.3` | 3.1.3 | [166](https://github.com/twentyhq/favicon/security/dependabot/166) |
| GHSA-v2hh-gcrm-f6hx | `>= 3.0.0, <= 3.1.3` | 3.1.4 | [168](https://github.com/twentyhq/favicon/security/dependabot/168) |

fast-uri is transitive behind a single caret range (`^3.0.1`), so a recursive `yarn up -R fast-uri` lifts it with **no resolution and no `package.json` change**. 3.1.4 satisfies both fix floors.

## Verification

- `yarn install --immutable` passes.
- Diff is `yarn.lock` only; fast-uri resolves to 3.1.4, no 3.1.2 remains.
