### PR TITLE
fix: bump brace-expansion to latest per line (Dependabot)

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -4678,30 +4678,30 @@ __metadata:
   linkType: hard
 
 "brace-expansion@npm:^1.1.7":
-  version: 1.1.15
-  resolution: "brace-expansion@npm:1.1.15"
+  version: 1.1.16
+  resolution: "brace-expansion@npm:1.1.16"
   dependencies:
     balanced-match: "npm:^1.0.0"
     concat-map: "npm:0.0.1"
-  checksum: 10c0/648e273f57cfa9ed67d8a77bdb15b408205465d33da9331808ee3c188d8b55674c9cdbf1f320b65bc562e485e1263360ae62ad355e128e0435891f6430e795d7
+  checksum: 10c0/b2a915bbedbf4e45840d1fb9a4d391bbf26a79475bd134714d3cee34f1f0edb0ce982738028843be5fbaf8039429f71fa487df8c915b6065ced542c83e58fae6
   languageName: node
   linkType: hard
 
 "brace-expansion@npm:^2.0.2":
-  version: 2.1.1
-  resolution: "brace-expansion@npm:2.1.1"
+  version: 2.1.2
+  resolution: "brace-expansion@npm:2.1.2"
   dependencies:
     balanced-match: "npm:^1.0.0"
-  checksum: 10c0/63b5ddce608b70b50a76817c0526faf8ea67a9180073d88bb402f6bbc22a22da6b1dfac4f65efc53e5faa80222fb7d44bbf2fc638c3f55365975573f671d0ccb
+  checksum: 10c0/5442ecab84045d21826268bc56c81a6ef4215327ee1f5ee153f67928e93f7a915d130ecec9966623143277fa3cce036ebb50020024bcc4d78853cdd6af9a19f8
   languageName: node
   linkType: hard
 
 "brace-expansion@npm:^5.0.5":
-  version: 5.0.6
-  resolution: "brace-expansion@npm:5.0.6"
+  version: 5.0.8
+  resolution: "brace-expansion@npm:5.0.8"
   dependencies:
     balanced-match: "npm:^4.0.2"
-  checksum: 10c0/8c919869b90f61d533b341d3340be5ee4413232ea89b8246cbc2f38eb014f1d8182785c98a006eaf6111d02dc9eeffefdc240d5ac158625b2ed084dccd4bbf9b
+  checksum: 10c0/73304caafd00fdc5b0168e693ac15bf25b6357dec76d1195fcd628fe2cf99c46f9c889a7ecfa3cfe236dbd2d5ce3e27a6ccc4370b46d475d0d19081e11f86019
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Bumps **brace-expansion** on all three lines - `1.1.15 -> 1.1.16`, `2.1.1 -> 2.1.2`, `5.0.6 -> 5.0.8` - clearing alert [159](https://github.com/twentyhq/favicon/security/dependabot/159): **GHSA-3jxr-9vmj-r5cp** (high, vulnerable `>= 3.0.0, < 5.0.7`).

Every copy sits behind a caret (`^1.1.7`, `^2.0.2`, `^5.0.5`), so a recursive `yarn up -R brace-expansion` lifts them with **no resolution and no `package.json` change**.

## Note on the newer advisory

Landing the 5.x copy on **5.0.8** rather than just meeting the 5.0.7 floor also covers **GHSA-mh99-v99m-4gvg** (vulnerable `<= 5.0.7`), which has already been flagged upstream in `twentyhq/twenty`.

That advisory declares a single range spanning **every** major line, so the 1.x and 2.x copies match it too - but **1.1.16 and 2.1.2 are the final releases** of those lines and the only patched version is 5.0.8. There is therefore no in-range fix for them; clearing those would mean forcing a cross-major jump via a resolution, which is a behavior risk rather than a mechanical lift. Left as-is.

## Verification

- `yarn install --immutable` passes.
- Diff is `yarn.lock` only; the three copies resolve to 1.1.16 / 2.1.2 / 5.0.8.
